### PR TITLE
remove needless sort

### DIFF
--- a/batched-page-processor.ts
+++ b/batched-page-processor.ts
@@ -19,24 +19,32 @@ async function clearBatchGraph() {
   );
 }
 
-async function countMembers() {
-  const members = await querySudo(
-    `SELECT (COUNT(?member) as ?count) WHERE {
+// note previously these members were sorted but this just wasted a lot of time and was not necessary
+// the old members were already removed in a previous step so all of these members should be independent of one another
+async function selectMembersFromBatch() {
+  logger.debug('Fetching members from batch');
+  const result = await querySudo(
+    `
+    SELECT DISTINCT ?member WHERE {
       GRAPH <${WORKING_GRAPH}> {
         ?stream <https://w3id.org/tree#member> ?member.
-        ?member ${sparqlEscapeUri(TIME_PREDICATE)} ?time.
       }
     }`,
     {},
     { sparqlEndpoint: DIRECT_DATABASE_CONNECTION, mayRetry: true },
   );
-  const count = members.results.bindings[0].count.value;
-  logger.debug(`Found ${count} members`);
-  return count;
+  const orderdMembers = result.results.bindings.map(
+    (binding) => binding.member.value,
+  );
+  logger.debug(`Found ${orderdMembers.length} members`);
+  return orderdMembers;
 }
 
-async function moveBatchToBatchingGraph() {
+async function moveBatchToBatchingGraph(batchOfMembers: string[]) {
   logger.debug('Moving batch to batching graph');
+  const safeMembers = batchOfMembers
+    .map((member) => sparqlEscapeUri(member))
+    .join('\n');
 
   await updateSudo(
     `
@@ -52,12 +60,9 @@ async function moveBatchToBatchingGraph() {
         ?member ?p ?o.
       }
     } WHERE {
-      { SELECT ?member ?stream ?time WHERE {
-        GRAPH <${WORKING_GRAPH}> {
-          ?stream <https://w3id.org/tree#member> ?member.
-          ?member ${sparqlEscapeUri(TIME_PREDICATE)} ?time.
-        }
-      } ORDER BY ?time ?member LIMIT ${BATCH_SIZE} }
+      VALUES ?member {
+        ${safeMembers}
+      }
 
       GRAPH <${WORKING_GRAPH}> {
         ?member ?p ?o.
@@ -144,23 +149,22 @@ async function cleanupOldVersions() {
   logger.debug('Old versions cleaned up');
 }
 
-async function processPageBatch() {
+async function processPageBatch(batchOfMembers: string[]) {
   logger.debug('Running custom logic to process the current page');
   await clearBatchGraph();
-  await moveBatchToBatchingGraph();
+  await moveBatchToBatchingGraph(batchOfMembers);
   await processPage();
   return;
 }
 
 export async function batchedProcessLDESPage() {
   logger.debug('Processing LDES page...');
-  if (logger.isLevelEnabled('debug')) {
-    // just for logging the count before cleaning old versions
-    await countMembers();
-  }
   await cleanupOldVersions();
-  while ((await countMembers()) > 0) {
-    await processPageBatch();
+  const allMembers = await selectMembersFromBatch();
+  while (allMembers.length > 0) {
+    const batch = allMembers.splice(0, BATCH_SIZE);
+    await processPageBatch(batch);
+    logger.debug(`Batch processed, ${allMembers.length} members left`);
   }
   await clearBatchGraph();
   logger.debug('LDES page processed');

--- a/cron-fetch-ldes.ts
+++ b/cron-fetch-ldes.ts
@@ -36,10 +36,14 @@ async function determineFirstPage(): Promise<StateInfo> {
 }
 
 async function determineNextPage() {
-  const page = await querySudo(`SELECT ?page WHERE { GRAPH <${WORKING_GRAPH}> {
+  const page = await querySudo(
+    `SELECT ?page WHERE { GRAPH <${WORKING_GRAPH}> {
     ?relation a <https://w3id.org/tree#GreaterThanOrEqualToRelation> .
     ?relation <https://w3id.org/tree#node> ?page.
-  } }`);
+  } }`,
+    {},
+    { sparqlEndpoint: DIRECT_DATABASE_CONNECTION },
+  );
 
   if (page.results.bindings.length === 0) {
     return null;


### PR DESCRIPTION

## Description
remove needless and repeated sort of items on a page. We are already removing the old instances, so sorting them by time is redundant.

also found a single case where we weren't calling virtuoso directly for our temp graph related ops, be consistent

## How to test

Run this on the new OP ldes for instance. Notice that it's more than 10x faster than before.
## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/391
