### PR TITLE
allow reading from multiple streams in a round robin fashion

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Sometimes you may want to do some post processing after the whole stream was pro
 
 - **CRON_PATTERN**: the cron pattern to use for the LDES client cron job. Default: _/5 _ \* \* \* \*
 - **FIRST_PAGE**: the url of the first page to load. Default https://mandatenbeheer.lblod.info/streams/ldes/public/1
-- **LDES_BASE**: the base url of the LDES feed. Default https://mandatenbeheer.lblod.info/streams/ldes/public/
+- **LDES_BASE**: the base url of the LDES feed. If left blank, uses the config/config.ts file to define properties for one or more LDES feeds (see config file)
 - **STATUS_GRAPH**: the URI of the status graph where this client keeps its status. Default: http://mu.semte.ch/graphs/status
 - **VERSION_PREDICATE**: the URI used for the predicate determining the version of the LDES members. Default: http://purl.org/dc/terms/isVersionOf
 - **TIME_PREDICATE**: the URI used for the predicate determining when the LDES member was generated. Default: http://www.w3.org/ns/prov#generatedAtTime
@@ -52,6 +52,31 @@ Sometimes you may want to do some post processing after the whole stream was pro
 - **BYPASS_MU_AUTH**: do not use mu-auth when writing to the target graph, resulting in no deltas being generated (but a faster processing of the stream). Default: false
 - **RANDOMIZE_GRAPHS**: Add a random /<uuid> suffix to the working and batch graph uris. Default: false. This is done because of an issue we experienced where virtuoso seems to keep some residue of dropped graphs, resulting in a very long (infinite?) waiting time for some queries.
 - **RUN_AT_STARTUP**: fetch the LDES at startup of the service, don't wait for the cronjob. Can be useful for development/debugging.
+
+## Config file and consuming multiple feeds
+
+The config file allows the consumption of multiple feeds, setting the environment variables per feed. Environment variables that can be set this way are:
+
+- LDES_BASE
+- FIRST_PAGE
+- TARGET_GRAPH
+- STATUS_GRAPH
+- EXTRA_HEADERS
+- VERSION_PREDICATE
+- TIME_PREDICATE
+
+If you use the config file, you are expected to read these environment varariables from the environment object like this:
+
+```ts
+import { environment } from '../environment';
+
+// [...]
+
+const TARGET_GRAPH = environment.getTargetGraph();
+```
+
+The client will fetch the variable for the currently active stream.
+To get the config for the currently active stream, use `environment.getCurrentStreamConfig()` e.g. if you want to use some different logic depending on the stream in your `processPage.ts` file.
 
 ## Known issues
 

--- a/batched-page-processor.ts
+++ b/batched-page-processor.ts
@@ -12,7 +12,7 @@ import { sparqlEscapeUri } from 'mu';
 
 async function clearBatchGraph() {
   await updateSudo(
-    `DROP SILENT GRAPH <${BATCH_GRAPH}>`,
+    `DROP SILENT GRAPH ${sparqlEscapeUri(BATCH_GRAPH)}`,
     {},
     { sparqlEndpoint: DIRECT_DATABASE_CONNECTION },
   );
@@ -25,7 +25,7 @@ async function selectMembersFromBatch() {
   const result = await querySudo(
     `
     SELECT DISTINCT ?member WHERE {
-      GRAPH <${WORKING_GRAPH}> {
+      GRAPH ${sparqlEscapeUri(WORKING_GRAPH)} {
         ?stream <https://w3id.org/tree#member> ?member.
       }
     }`,
@@ -48,13 +48,13 @@ async function moveBatchToBatchingGraph(batchOfMembers: string[]) {
   await updateSudo(
     `
     DELETE {
-      GRAPH <${WORKING_GRAPH}> {
+      GRAPH ${sparqlEscapeUri(WORKING_GRAPH)} {
         ?stream <https://w3id.org/tree#member> ?member.
         ?member ?p ?o.
       }
     }
     INSERT {
-      GRAPH <${BATCH_GRAPH}> {
+      GRAPH ${sparqlEscapeUri(BATCH_GRAPH)} {
         ?stream <https://w3id.org/tree#member> ?member.
         ?member ?p ?o.
       }
@@ -63,7 +63,7 @@ async function moveBatchToBatchingGraph(batchOfMembers: string[]) {
         ${safeMembers}
       }
 
-      GRAPH <${WORKING_GRAPH}> {
+      GRAPH ${sparqlEscapeUri(WORKING_GRAPH)} {
         ?stream <https://w3id.org/tree#member> ?member.
         ?member ?p ?o.
       }
@@ -81,7 +81,7 @@ async function hasMultipleVersionsOnPage() {
   const hasMultipleVersions = await querySudo(
     `
       SELECT ?oldMember WHERE {
-       GRAPH <${WORKING_GRAPH}> {
+       GRAPH ${sparqlEscapeUri(WORKING_GRAPH)} {
          ?stream <https://w3id.org/tree#member> ?oldMember.
          ?oldMember <http://purl.org/dc/terms/isVersionOf> ?trueUri.
          FILTER EXISTS {
@@ -104,11 +104,11 @@ async function markOldVersions() {
   await updateSudo(
     ` PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       INSERT {
-        GRAPH <${WORKING_GRAPH}> {
+        GRAPH ${sparqlEscapeUri(WORKING_GRAPH)} {
           ?oldMember ext:isOldMember ext:isOldMember.
         }
       } WHERE {
-        GRAPH <${WORKING_GRAPH}> {
+        GRAPH ${sparqlEscapeUri(WORKING_GRAPH)} {
           ?stream <https://w3id.org/tree#member> ?oldMember.
           ?oldMember ${sparqlEscapeUri(VERSION_PREDICATE)} ?trueUri.
           ?oldMember ${sparqlEscapeUri(TIME_PREDICATE)} ?oldTime.
@@ -136,11 +136,11 @@ async function cleanupOldVersions() {
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
     DELETE {
-      GRAPH <${WORKING_GRAPH}> {
+      GRAPH ${sparqlEscapeUri(WORKING_GRAPH)} {
         ?stream <https://w3id.org/tree#member> ?oldMember.
       }
     } WHERE {
-      GRAPH <${WORKING_GRAPH}> {
+      GRAPH ${sparqlEscapeUri(WORKING_GRAPH)} {
         ?stream <https://w3id.org/tree#member> ?oldMember.
         ?oldMember ext:isOldMember ext:isOldMember.
       }

--- a/batched-page-processor.ts
+++ b/batched-page-processor.ts
@@ -4,8 +4,7 @@ import {
   BATCH_GRAPH,
   BATCH_SIZE,
   DIRECT_DATABASE_CONNECTION,
-  TIME_PREDICATE,
-  VERSION_PREDICATE,
+  environment,
   WORKING_GRAPH,
 } from './environment';
 import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
@@ -100,6 +99,8 @@ async function hasMultipleVersionsOnPage() {
 }
 
 async function markOldVersions() {
+  const VERSION_PREDICATE = environment.getVersionPredicate();
+  const TIME_PREDICATE = environment.getTimePredicate();
   await updateSudo(
     ` PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       INSERT {

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,3 @@
 # v0.1.0
 
-- Breaking change: the client can now rotate and fetch from multiple ldes feeds with different configurations. This means that you should use environment.getTargetGraph etc. to read the config instead of simply importing TARGET_GRAPH from the environment. If the LDES_BASE env var is not set, the settings are read from the config.ts file in the config directory.
+- the client can now rotate and fetch from multiple ldes feeds with different configurations. This means that you should use environment.getTargetGraph etc. to read the config instead of simply importing TARGET_GRAPH from the environment. If the LDES_BASE env var is not set, the settings are read from the config.ts file in the config directory.

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,3 @@
+# v0.1.0
+
+- Breaking change: the client can now rotate and fetch from multiple ldes feeds with different configurations. This means that you should use environment.getTargetGraph etc. to read the config instead of simply importing TARGET_GRAPH from the environment. If the LDES_BASE env var is not set, the settings are read from the config.ts file in the config directory.

--- a/config/config.ts
+++ b/config/config.ts
@@ -1,0 +1,14 @@
+export default {
+  endpoints: [
+    {
+      name: 'Stream 1',
+      LDES_BASE: 'https://locally-managed/streams/ldes-1/abb/',
+      FIRST_PAGE: 'https://locally-managed/streams/ldes-1/abb/1',
+      TARGET_GRAPH: 'http://mu.semte.ch/graphs/locally-managed',
+      STATUS_GRAPH: 'http://mu.semte.ch/graphs/locally-managed/status',
+      EXTRA_HEADERS: {},
+      VERSION_PREDICATE: 'http://purl.org/dc/terms/isVersionOf',
+      TIME_PREDICATE: 'http://www.w3.org/ns/prov#generatedAtTime',
+    },
+  ],
+};

--- a/config/processPage.ts
+++ b/config/processPage.ts
@@ -6,9 +6,7 @@ import {
   BATCH_GRAPH,
   BYPASS_MU_AUTH,
   DIRECT_DATABASE_CONNECTION,
-  TARGET_GRAPH,
-  TIME_PREDICATE,
-  VERSION_PREDICATE,
+  environment,
 } from '../environment';
 
 async function replaceExistingData() {
@@ -21,23 +19,23 @@ async function replaceExistingData() {
   await updateSudo(
     `
     DELETE {
-      GRAPH ${sparqlEscapeUri(TARGET_GRAPH)} {
+      GRAPH ${sparqlEscapeUri(environment.getTargetGraph())} {
         ?s ?pOld ?oOld.
       }
     }
     INSERT {
-      GRAPH ${sparqlEscapeUri(TARGET_GRAPH)} {
+      GRAPH ${sparqlEscapeUri(environment.getTargetGraph())} {
         ?s ?pNew ?oNew.
       }
     } WHERE {
       GRAPH ${sparqlEscapeUri(BATCH_GRAPH)} {
         ?stream <https://w3id.org/tree#member> ?versionedMember .
-        ?versionedMember ${sparqlEscapeUri(VERSION_PREDICATE)} ?s .
+        ?versionedMember ${sparqlEscapeUri(environment.getVersionPredicate())} ?s .
         ?versionedMember ?pNew ?oNew.
-        FILTER (?pNew NOT IN ( ${sparqlEscapeUri(VERSION_PREDICATE)}, ${sparqlEscapeUri(TIME_PREDICATE)} ))
+        FILTER (?pNew NOT IN ( ${sparqlEscapeUri(environment.getVersionPredicate())}, ${sparqlEscapeUri(environment.getTimePredicate())} ))
       }
       OPTIONAL {
-        GRAPH ${sparqlEscapeUri(TARGET_GRAPH)} {
+        GRAPH ${sparqlEscapeUri(environment.getTargetGraph())} {
           ?s ?pOld ?oOld.
         }
       }

--- a/cron-fetch-ldes.ts
+++ b/cron-fetch-ldes.ts
@@ -122,13 +122,22 @@ async function fetchLdes() {
   logger.info('LDES fetched, all done!');
 }
 
+const roundRobinFetchLdes = async () => {
+  let hasNextStream = true;
+  environment.resetCurrentStream();
+  while (hasNextStream) {
+    await fetchLdes();
+    hasNextStream = environment.toNextStream();
+  }
+};
+
 export const safeFetchLdes = async () => {
   if (runningState.lastRun) {
     logger.debug('Another job is already running...');
     return;
   }
   runningState.lastRun = new Date();
-  await fetchLdes();
+  await roundRobinFetchLdes();
   runningState.lastRun = null;
 };
 

--- a/cron-fetch-ldes.ts
+++ b/cron-fetch-ldes.ts
@@ -5,11 +5,9 @@ import { URL } from 'url';
 import {
   DIRECT_DATABASE_CONNECTION,
   GRAPH_STORE_URL,
-  LDES_BASE,
   WORKING_GRAPH,
-  FIRST_PAGE,
   CRON_PATTERN,
-  EXTRA_HEADERS,
+  environment,
 } from './environment';
 import { batchedProcessLDESPage } from './batched-page-processor';
 import {
@@ -28,7 +26,7 @@ async function determineFirstPage(): Promise<StateInfo> {
     return {
       lastTime: new Date(0).toISOString(),
       lastTimeCount: 0,
-      currentPage: FIRST_PAGE,
+      currentPage: environment.getFirstPage(),
       nextPage: null,
     };
   }
@@ -49,7 +47,8 @@ async function determineNextPage() {
     return null;
   }
 
-  return new URL(page.results.bindings[0].page.value, LDES_BASE).href;
+  return new URL(page.results.bindings[0].page.value, environment.getLdesBase())
+    .href;
 }
 
 async function clearWorkingGraph() {
@@ -65,7 +64,7 @@ async function loadLDESPage(url: string) {
   const response = await fetch(url, {
     headers: {
       Accept: 'text/turtle',
-      ...EXTRA_HEADERS,
+      ...environment.getExtraHeaders(),
     },
   });
   if (!response.ok) {

--- a/cron-fetch-ldes.ts
+++ b/cron-fetch-ldes.ts
@@ -1,6 +1,7 @@
 import { CronJob } from 'cron';
 import { logger } from './logger';
 import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
+import { sparqlEscapeUri } from 'mu';
 import { URL } from 'url';
 import {
   DIRECT_DATABASE_CONNECTION,
@@ -35,7 +36,7 @@ async function determineFirstPage(): Promise<StateInfo> {
 
 async function determineNextPage() {
   const page = await querySudo(
-    `SELECT ?page WHERE { GRAPH <${WORKING_GRAPH}> {
+    `SELECT ?page WHERE { GRAPH ${sparqlEscapeUri(WORKING_GRAPH)} {
     ?relation a <https://w3id.org/tree#GreaterThanOrEqualToRelation> .
     ?relation <https://w3id.org/tree#node> ?page.
   } }`,
@@ -53,7 +54,7 @@ async function determineNextPage() {
 
 async function clearWorkingGraph() {
   await updateSudo(
-    `DROP SILENT GRAPH <${WORKING_GRAPH}>`,
+    `DROP SILENT GRAPH ${sparqlEscapeUri(WORKING_GRAPH)}`,
     {},
     { sparqlEndpoint: DIRECT_DATABASE_CONNECTION },
   );

--- a/environment.ts
+++ b/environment.ts
@@ -93,6 +93,9 @@ export const environment = {
   getCurrentStreamConfig() {
     return config.endpoints[currentStream];
   },
+  resetCurrentStream() {
+    currentStream = 0;
+  },
   toNextStream() {
     currentStream++;
     if (currentStream >= config.endpoints.length) {

--- a/environment.ts
+++ b/environment.ts
@@ -4,8 +4,8 @@ import config from './config/config';
 export const RANDOMIZE_GRAPHS =
   (process.env.RANDOMIZE_GRAPHS || 'false') === 'true';
 export const CRON_PATTERN = process.env.CRON_PATTERN || '*/5 * * * * *';
-const LDES_BASE = process.env.LDES_BASE;
-const FIRST_PAGE =
+export const LDES_BASE = process.env.LDES_BASE;
+export const FIRST_PAGE =
   process.env.FIRST_PAGE ||
   'https://dev.mandatenbeheer.lblod.info/streams/ldes/public/1';
 export const WORKING_GRAPH =
@@ -15,20 +15,20 @@ export const BATCH_GRAPH =
   (process.env.BATCH_GRAPH || 'http://mu.semte.ch/graphs/batch') +
   (RANDOMIZE_GRAPHS ? `/${uuid()}` : '');
 export const BATCH_SIZE = process.env.BATCH_SIZE || 1000;
-const STATUS_GRAPH =
+export const STATUS_GRAPH =
   process.env.STATUS_GRAPH || 'http://mu.semte.ch/graphs/status';
-const TARGET_GRAPH =
+export const TARGET_GRAPH =
   process.env.TARGET_GRAPH || 'http://mu.semte.ch/graphs/public';
 export const DIRECT_DATABASE_CONNECTION =
   process.env.DIRECT_DATABASE_CONNECTION || 'http://virtuoso:8890/sparql';
 export const GRAPH_STORE_URL =
   process.env.GRAPH_STORE_URL || 'http://virtuoso:8890/sparql-graph-crud';
-const VERSION_PREDICATE =
+export const VERSION_PREDICATE =
   process.env.VERSION_PREDICATE || 'http://purl.org/dc/terms/isVersionOf';
-const TIME_PREDICATE =
+export const TIME_PREDICATE =
   process.env.TIME_PREDICATE || 'http://www.w3.org/ns/prov#generatedAtTime';
 export const LOG_LEVEL = process.env.LOG_LEVEL || 'info';
-const EXTRA_HEADERS = JSON.parse(process.env.EXTRA_HEADERS || '{}');
+export const EXTRA_HEADERS = JSON.parse(process.env.EXTRA_HEADERS || '{}');
 export const BYPASS_MU_AUTH =
   (process.env.BYPASS_MU_AUTH || 'false') === 'true';
 export const RUN_AT_STARTUP =

--- a/environment.ts
+++ b/environment.ts
@@ -1,12 +1,11 @@
 import { v4 as uuid } from 'uuid';
+import config from './config/config';
 
 export const RANDOMIZE_GRAPHS =
   (process.env.RANDOMIZE_GRAPHS || 'false') === 'true';
 export const CRON_PATTERN = process.env.CRON_PATTERN || '*/5 * * * * *';
-export const LDES_BASE =
-  process.env.LDES_BASE ||
-  'https://dev.mandatenbeheer.lblod.info/streams/ldes/public/';
-export const FIRST_PAGE =
+const LDES_BASE = process.env.LDES_BASE;
+const FIRST_PAGE =
   process.env.FIRST_PAGE ||
   'https://dev.mandatenbeheer.lblod.info/streams/ldes/public/1';
 export const WORKING_GRAPH =
@@ -16,40 +15,89 @@ export const BATCH_GRAPH =
   (process.env.BATCH_GRAPH || 'http://mu.semte.ch/graphs/batch') +
   (RANDOMIZE_GRAPHS ? `/${uuid()}` : '');
 export const BATCH_SIZE = process.env.BATCH_SIZE || 1000;
-export const STATUS_GRAPH =
+const STATUS_GRAPH =
   process.env.STATUS_GRAPH || 'http://mu.semte.ch/graphs/status';
-export const TARGET_GRAPH =
+const TARGET_GRAPH =
   process.env.TARGET_GRAPH || 'http://mu.semte.ch/graphs/public';
 export const DIRECT_DATABASE_CONNECTION =
   process.env.DIRECT_DATABASE_CONNECTION || 'http://virtuoso:8890/sparql';
 export const GRAPH_STORE_URL =
   process.env.GRAPH_STORE_URL || 'http://virtuoso:8890/sparql-graph-crud';
-export const VERSION_PREDICATE =
+const VERSION_PREDICATE =
   process.env.VERSION_PREDICATE || 'http://purl.org/dc/terms/isVersionOf';
-export const TIME_PREDICATE =
+const TIME_PREDICATE =
   process.env.TIME_PREDICATE || 'http://www.w3.org/ns/prov#generatedAtTime';
 export const LOG_LEVEL = process.env.LOG_LEVEL || 'info';
-export const EXTRA_HEADERS = JSON.parse(process.env.EXTRA_HEADERS || '{}');
+const EXTRA_HEADERS = JSON.parse(process.env.EXTRA_HEADERS || '{}');
 export const BYPASS_MU_AUTH =
   (process.env.BYPASS_MU_AUTH || 'false') === 'true';
 export const RUN_AT_STARTUP =
   (process.env.RUN_AT_STARTUP || 'false') === 'true';
 
+let currentStream = 0;
+
 export const environment = {
   CRON_PATTERN,
-  LDES_BASE,
-  FIRST_PAGE,
   WORKING_GRAPH,
   BATCH_GRAPH,
   BATCH_SIZE,
-  STATUS_GRAPH,
-  TARGET_GRAPH,
   DIRECT_DATABASE_CONNECTION,
   GRAPH_STORE_URL,
-  VERSION_PREDICATE,
-  TIME_PREDICATE,
   LOG_LEVEL,
-  EXTRA_HEADERS,
   BYPASS_MU_AUTH,
   RANDOMIZE_GRAPHS,
+  // getters for the other properties so we can loop over multiple streams defined in the config
+  // if LDES_BASE is set, use the environment variables and don't look at the config file, if it isn't set, use the config file
+  getLdesBase() {
+    if (LDES_BASE) {
+      return LDES_BASE;
+    }
+    return config.endpoints[currentStream].LDES_BASE;
+  },
+  getFirstPage() {
+    if (LDES_BASE) {
+      return FIRST_PAGE;
+    }
+    return config.endpoints[currentStream].FIRST_PAGE;
+  },
+  getTargetGraph() {
+    if (LDES_BASE) {
+      return TARGET_GRAPH;
+    }
+    return config.endpoints[currentStream].TARGET_GRAPH;
+  },
+  getStatusGraph() {
+    if (LDES_BASE) {
+      return STATUS_GRAPH;
+    }
+    return config.endpoints[currentStream].STATUS_GRAPH;
+  },
+  getExtraHeaders() {
+    if (LDES_BASE) {
+      return EXTRA_HEADERS;
+    }
+    return config.endpoints[currentStream].EXTRA_HEADERS;
+  },
+  getVersionPredicate() {
+    if (LDES_BASE) {
+      return VERSION_PREDICATE;
+    }
+    return config.endpoints[currentStream].VERSION_PREDICATE;
+  },
+  getTimePredicate() {
+    if (LDES_BASE) {
+      return TIME_PREDICATE;
+    }
+    return config.endpoints[currentStream].TIME_PREDICATE;
+  },
+  getCurrentStreamConfig() {
+    return config.endpoints[currentStream];
+  },
+  toNextStream() {
+    currentStream++;
+    if (currentStream >= config.endpoints.length) {
+      currentStream = 0;
+    }
+    return currentStream != 0;
+  },
 };

--- a/manage-state.ts
+++ b/manage-state.ts
@@ -30,7 +30,7 @@ export async function gatherStateInfo(currentPage): Promise<StateInfo> {
   const lastTime = await querySudo(
     `
     SELECT ?stream ?lastTime ?nextPage WHERE {
-      GRAPH <${WORKING_GRAPH}> {
+      GRAPH ${sparqlEscapeUri(WORKING_GRAPH)} {
         ?stream a <http://w3id.org/ldes#EventStream> .
         OPTIONAL {
           ?stream <https://w3id.org/tree#member> ?versionedMember.
@@ -52,7 +52,7 @@ export async function gatherStateInfo(currentPage): Promise<StateInfo> {
   const lastTimeCount = await querySudo(
     `
     SELECT (COUNT(?versionedMember) as ?count) WHERE {
-      GRAPH <${WORKING_GRAPH}> {
+      GRAPH ${sparqlEscapeUri(WORKING_GRAPH)} {
         ?stream <https://w3id.org/tree#member> ?versionedMember.
         ?stream ${sparqlEscapeUri(environment.getTimePredicate())} ${sparqlEscapeDateTime(lastTimeValue)}.
       }
@@ -76,11 +76,11 @@ export async function saveState(stateInfo: StateInfo) {
     `
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     DELETE {
-      GRAPH <${environment.getStatusGraph()}> {
+      GRAPH ${sparqlEscapeUri(environment.getStatusGraph())} {
         ?s ?p ?o.
       }
     } WHERE {
-      GRAPH <${environment.getStatusGraph()}> {
+      GRAPH ${sparqlEscapeUri(environment.getStatusGraph())} {
         ?s a ext:LDESClientState ;
            ext:LDESStream ${sparqlEscapeUri(stream)} ;
            ?p ?o.
@@ -89,7 +89,7 @@ export async function saveState(stateInfo: StateInfo) {
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
     INSERT DATA {
-      GRAPH <${environment.getStatusGraph()}> {
+      GRAPH ${sparqlEscapeUri(environment.getStatusGraph())} {
         ${uri} a ext:LDESClientState ;
             ext:LDESStream ${sparqlEscapeUri(stream)} ;
             ext:LDESState ${sparqlEscapeString(JSON.stringify(stateInfo))} .
@@ -106,7 +106,7 @@ export async function loadState(): Promise<StateInfo | null> {
     `
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     SELECT ?state WHERE {
-      GRAPH <${environment.getStatusGraph()}> {
+      GRAPH ${sparqlEscapeUri(environment.getStatusGraph())} {
         ?s a ext:LDESClientState ;
             ext:LDESStream ${sparqlEscapeUri(stream)} ;
             ext:LDESState ?state.

--- a/manage-state.ts
+++ b/manage-state.ts
@@ -1,9 +1,7 @@
 import { querySudo, updateSudo } from '@lblod/mu-auth-sudo';
 import {
   DIRECT_DATABASE_CONNECTION,
-  LDES_BASE,
-  STATUS_GRAPH,
-  TIME_PREDICATE,
+  environment,
   WORKING_GRAPH,
 } from './environment';
 import { sparqlEscapeUri, sparqlEscapeDateTime, sparqlEscapeString } from 'mu';
@@ -36,7 +34,7 @@ export async function gatherStateInfo(currentPage): Promise<StateInfo> {
         ?stream a <http://w3id.org/ldes#EventStream> .
         OPTIONAL {
           ?stream <https://w3id.org/tree#member> ?versionedMember.
-          ?versionedMember ${sparqlEscapeUri(TIME_PREDICATE)} ?lastTime.
+          ?versionedMember ${sparqlEscapeUri(environment.getTimePredicate())} ?lastTime.
         }
         OPTIONAL {
           ?relation a <https://w3id.org/tree#GreaterThanOrEqualToRelation>.
@@ -56,7 +54,7 @@ export async function gatherStateInfo(currentPage): Promise<StateInfo> {
     SELECT (COUNT(?versionedMember) as ?count) WHERE {
       GRAPH <${WORKING_GRAPH}> {
         ?stream <https://w3id.org/tree#member> ?versionedMember.
-        ?stream ${sparqlEscapeUri(TIME_PREDICATE)} ${sparqlEscapeDateTime(lastTimeValue)}.
+        ?stream ${sparqlEscapeUri(environment.getTimePredicate())} ${sparqlEscapeDateTime(lastTimeValue)}.
       }
     }`,
     {},
@@ -72,17 +70,17 @@ export async function gatherStateInfo(currentPage): Promise<StateInfo> {
 }
 
 export async function saveState(stateInfo: StateInfo) {
-  const stream = LDES_BASE;
+  const stream = environment.getLdesBase();
   const uri = `ext:ldes-state-${uuid()}`;
   await updateSudo(
     `
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     DELETE {
-      GRAPH <${STATUS_GRAPH}> {
+      GRAPH <${environment.getStatusGraph()}> {
         ?s ?p ?o.
       }
     } WHERE {
-      GRAPH <${STATUS_GRAPH}> {
+      GRAPH <${environment.getStatusGraph()}> {
         ?s a ext:LDESClientState ;
            ext:LDESStream ${sparqlEscapeUri(stream)} ;
            ?p ?o.
@@ -91,7 +89,7 @@ export async function saveState(stateInfo: StateInfo) {
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
     INSERT DATA {
-      GRAPH <${STATUS_GRAPH}> {
+      GRAPH <${environment.getStatusGraph()}> {
         ${uri} a ext:LDESClientState ;
             ext:LDESStream ${sparqlEscapeUri(stream)} ;
             ext:LDESState ${sparqlEscapeString(JSON.stringify(stateInfo))} .
@@ -103,12 +101,12 @@ export async function saveState(stateInfo: StateInfo) {
 }
 
 export async function loadState(): Promise<StateInfo | null> {
-  const stream = LDES_BASE;
+  const stream = environment.getLdesBase();
   const state = await querySudo(
     `
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     SELECT ?state WHERE {
-      GRAPH <${STATUS_GRAPH}> {
+      GRAPH <${environment.getStatusGraph()}> {
         ?s a ext:LDESClientState ;
             ext:LDESStream ${sparqlEscapeUri(stream)} ;
             ext:LDESState ?state.


### PR DESCRIPTION
## Description

allows the client to read mulitple streams in a round robin fashion, reading one feed after another as far as it can go and when it reaches the last page, skipping to the next feed.
the feeds are described in the config file. This process is documented in the readme.
## How to test

see https://github.com/lblod/app-lokaal-mandatenbeheer/pull/430 for an example case
## Links to other PR's

- https://github.com/lblod/app-lokaal-mandatenbeheer/pull/430
