### PR TITLE
Update base image to version 1.9.1 and convert to es module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM semtech/mu-javascript-template:1.8.0
+FROM semtech/mu-javascript-template:1.9.1
 LABEL maintainer="karel.kremer@redpencil.io"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "mandataris-service",
   "version": "0.0.3",
   "description": "Service to handle backend business logic for mandataris instances",
+  "type": "module",
   "main": "app.js",
   "author": "redpencil.io",
   "license": "MIT",


### PR DESCRIPTION
## Description
This PR updates the base image to version 1.9.1, and converts the project to an es module. This will allow us to use esmodule dependencies.

## How to test
This PR does not impact the functionality of the service, it should just work as before
