### PR TITLE
Make relationship rdf-type of next page configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Sometimes you may want to do some post processing after the whole stream was pro
 - **STATUS_GRAPH**: the URI of the status graph where this client keeps its status. Default: http://mu.semte.ch/graphs/status
 - **VERSION_PREDICATE**: the URI used for the predicate determining the version of the LDES members. Default: http://purl.org/dc/terms/isVersionOf
 - **TIME_PREDICATE**: the URI used for the predicate determining when the LDES member was generated. Default: http://www.w3.org/ns/prov#generatedAtTime
+- **NEXT_PAGE_RELATIONSHIP_RDF_TYPE**: the RDF type of the relationship pointing to the next page. Default: https://w3id.org/tree#GreaterThanOrEqualToRelation
 - **WORKING_GRAPH**: the URI of the working graph where the raw information of the LDES feed is kept temporarily for processing. Default: http://mu.semte.ch/graphs/temp.
 - **BATCH_GRAPH**: the URI of the graph where the raw information is moved to for batching. Batching is used because we don't want to overwhelm mu-auth with very heavy insert/delete queries. Default: http://mu.semte.ch/graphs/ldes-batch.
 - **BATCH_SIZE**: the size of batches in _count of members_, the number of triples will be larger. Default: 1000
@@ -64,6 +65,7 @@ The config file allows the consumption of multiple feeds, setting the environmen
 - EXTRA_HEADERS
 - VERSION_PREDICATE
 - TIME_PREDICATE
+- NEXT_PAGE_RELATIONSHIP_RDF_TYPE
 
 If you use the config file, you are expected to read these environment varariables from the environment object like this:
 

--- a/config/config.ts
+++ b/config/config.ts
@@ -9,6 +9,8 @@ export default {
       EXTRA_HEADERS: {},
       VERSION_PREDICATE: 'http://purl.org/dc/terms/isVersionOf',
       TIME_PREDICATE: 'http://www.w3.org/ns/prov#generatedAtTime',
+      NEXT_PAGE_RELATIONSHIP_RDF_TYPE:
+        'https://w3id.org/tree#GreaterThanOrEqualToRelation',
     },
   ],
 };

--- a/cron-fetch-ldes.ts
+++ b/cron-fetch-ldes.ts
@@ -37,7 +37,7 @@ async function determineFirstPage(): Promise<StateInfo> {
 async function determineNextPage() {
   const page = await querySudo(
     `SELECT ?page WHERE { GRAPH ${sparqlEscapeUri(WORKING_GRAPH)} {
-    ?relation a <https://w3id.org/tree#GreaterThanOrEqualToRelation> .
+    ?relation a ${sparqlEscapeUri(environment.getNextPageRelationshipRdfType())} .
     ?relation <https://w3id.org/tree#node> ?page.
   } }`,
     {},

--- a/environment.ts
+++ b/environment.ts
@@ -34,6 +34,12 @@ export const BYPASS_MU_AUTH =
 export const RUN_AT_STARTUP =
   (process.env.RUN_AT_STARTUP || 'false') === 'true';
 
+const DEFAULT_NEXT_PAGE_RELATIONSHIP_RDF_TYPE =
+  'https://w3id.org/tree#GreaterThanOrEqualToRelation';
+export const NEXT_PAGE_RELATIONSHIP_RDF_TYPE =
+  process.env.NEXT_PAGE_RELATIONSHIP_RDF_TYPE ||
+  DEFAULT_NEXT_PAGE_RELATIONSHIP_RDF_TYPE;
+
 let currentStream = 0;
 
 export const environment = {
@@ -89,6 +95,15 @@ export const environment = {
       return TIME_PREDICATE;
     }
     return config.endpoints[currentStream].TIME_PREDICATE;
+  },
+  getNextPageRelationshipRdfType() {
+    if (LDES_BASE) {
+      return NEXT_PAGE_RELATIONSHIP_RDF_TYPE;
+    }
+    return (
+      config.endpoints[currentStream].NEXT_PAGE_RELATIONSHIP_RDF_TYPE ||
+      DEFAULT_NEXT_PAGE_RELATIONSHIP_RDF_TYPE
+    );
   },
   getCurrentStreamConfig() {
     return config.endpoints[currentStream];

--- a/manage-state.ts
+++ b/manage-state.ts
@@ -37,7 +37,7 @@ export async function gatherStateInfo(currentPage): Promise<StateInfo> {
           ?versionedMember ${sparqlEscapeUri(environment.getTimePredicate())} ?lastTime.
         }
         OPTIONAL {
-          ?relation a <https://w3id.org/tree#GreaterThanOrEqualToRelation>.
+          ?relation a ${sparqlEscapeUri(environment.getNextPageRelationshipRdfType())}.
           ?relation <https://w3id.org/tree#node> ?nextPage.
         }
       }


### PR DESCRIPTION
## Description
This PR makes the rdf-type of the relationship point to the next page configurable through the `NEXT_PAGE_RELATIONSHIP_RDF_TYPE` environment variable.
The default value of this environment variable is `https://w3id.org/tree#GreaterThanOrEqualToRelation`

## How to test
By default, this PR should not impact the behaviour of this service, as by default the `https://w3id.org/tree#GreaterThanOrEqualToRelation` is still used.
I created this PR as we are consuming a feed which uses the `https://w3id.org/tree#Relation` type instead of `https://w3id.org/tree#GreaterThanOrEqualToRelation`
