### PR TITLE
Add support for JWT authorization

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,7 +15,6 @@ module.exports = {
   },
   plugins: ['@typescript-eslint'],
   rules: {
-    indent: ['error', 2, { SwitchCase: 1 }],
     'linebreak-style': ['error', 'unix'],
     quotes: ['error', 'single'],
     semi: ['error', 'always'],

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ Sometimes you may want to do some post processing after the whole stream was pro
 - **RANDOMIZE_GRAPHS**: Add a random /<uuid> suffix to the working and batch graph uris. Default: false. This is done because of an issue we experienced where virtuoso seems to keep some residue of dropped graphs, resulting in a very long (infinite?) waiting time for some queries.
 - **RUN_AT_STARTUP**: fetch the LDES at startup of the service, don't wait for the cronjob. Can be useful for development/debugging.
 
+### Environment variables for JWT authorization
+- **USE_JWT_AUTH**: boolean indicating whether to set an authorization header based on a json web key (JWK) and json web token (JWT). Default: false
+- **JWT_CLIENT_ID**: client ID corresponding to configured JWK.
+- **JWT_KEY_PATH**: path to the JWK. Default: `/config/jwk.json`
+- **JWT_KEY_ALGORITHM**: the algorithm used to generate the JWK. Default: `RS256`
+- **JWT_TOKEN_URL**: URL to request access token from.
+- **JWT_TOKEN_REQUEST_AUDIENCE**: audience to set in the JWT when requesting an access token.
+- **JWT_TOKEN_REQUEST_EXPIRY**: the expiry of the signed JWT used to request the access token. Note: this is not the same as the expiry of the token itself. Default: `10minutes`
+- **JWT_TOKEN_SCOPE**: the scope of the access token being requested.
+- **JWT_CLIENT_ASSERTION_TYPE**: the assertion type of the access token being requested. Default: `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`
+
 ## Config file and consuming multiple feeds
 
 The config file allows the consumption of multiple feeds, setting the environment variables per feed. Environment variables that can be set this way are:
@@ -70,6 +81,15 @@ The config file allows the consumption of multiple feeds, setting the environmen
 - NEXT_PAGE_RELATIONSHIP_RDF_TYPE
 - SKOLEMIZE_BLANK_NODES
 - SKOLEMIZATION_BASE_URI
+- USE_JWT_AUTH
+- JWT_CLIENT_ID
+- JWT_KEY_PATH
+- JWT_KEY_ALGORITHM
+- JWT_TOKEN_URL
+- JWT_TOKEN_REQUEST_AUDIENCE
+- JWT_TOKEN_REQUEST_EXPIRY
+- JWT_TOKEN_SCOPE
+- JWT_CLIENT_ASSERTION_TYPE
 
 If you use the config file, you are expected to read these environment varariables from the environment object like this:
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Sometimes you may want to do some post processing after the whole stream was pro
 ## Environment Variables
 
 - **CRON_PATTERN**: the cron pattern to use for the LDES client cron job. Default: _/5 _ \* \* \* \*
+- **DELAY**: a delay in milliseconds to introduce between fetching/processing LDES pages. Can be used to reduce load on LDES feed and/or the database. Default: 0. 
 - **FIRST_PAGE**: the url of the first page to load. Default https://mandatenbeheer.lblod.info/streams/ldes/public/1
 - **LDES_BASE**: the base url of the LDES feed. If left blank, uses the config/config.ts file to define properties for one or more LDES feeds (see config file)
 - **STATUS_GRAPH**: the URI of the status graph where this client keeps its status. Default: http://mu.semte.ch/graphs/status

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Sometimes you may want to do some post processing after the whole stream was pro
 ### Environment variables for JWT authorization
 - **USE_JWT_AUTH**: boolean indicating whether to set an authorization header based on a json web key (JWK) and json web token (JWT). Default: false
 - **JWT_CLIENT_ID**: client ID corresponding to configured JWK.
-- **JWT_KEY_PATH**: path to the JWK. Default: `/config/jwk.json`
+- **JWT_KEY**: JSON Web Key.
 - **JWT_KEY_ALGORITHM**: the algorithm used to generate the JWK. Default: `RS256`
 - **JWT_TOKEN_URL**: URL to request access token from.
 - **JWT_TOKEN_REQUEST_AUDIENCE**: audience to set in the JWT when requesting an access token.
@@ -83,7 +83,7 @@ The config file allows the consumption of multiple feeds, setting the environmen
 - SKOLEMIZATION_BASE_URI
 - USE_JWT_AUTH
 - JWT_CLIENT_ID
-- JWT_KEY_PATH
+- JWT_KEY (can be both passed in encoded and decoded version)
 - JWT_KEY_ALGORITHM
 - JWT_TOKEN_URL
 - JWT_TOKEN_REQUEST_AUDIENCE

--- a/app.ts
+++ b/app.ts
@@ -40,5 +40,6 @@ setTimeout(() => {
 if (RUN_AT_STARTUP) {
   safeFetchLdes().catch((e) => {
     console.log('Failed to fetch LDES on startup: ', e);
+    process.exit(1);
   });
 }

--- a/config/config.ts
+++ b/config/config.ts
@@ -1,3 +1,32 @@
+export type Config = {
+  name: string;
+  LDES_BASE: string;
+  FIRST_PAGE: string;
+  TARGET_GRAPH: string;
+  STATUS_GRAPH: string;
+  EXTRA_HEADERS: Headers;
+  VERSION_PREDICATE: string;
+  TIME_PREDICATE: string;
+  NEXT_PAGE_RELATIONSHIP_RDF_TYPE?: string;
+  SKOLEMIZE_BLANK_NODES?: boolean;
+  SKOLEMIZATION_BASE_URI?: string;
+} & (
+  | {
+      USE_JWT_AUTH: true;
+      JWT_CLIENT_ID: string;
+      JWT_KEY_PATH: string;
+      JWT_KEY_ALGORITHM: string;
+      JWT_TOKEN_URL: string;
+      JWT_TOKEN_REQUEST_AUDIENCE: string;
+      JWT_TOKEN_REQUEST_EXPIRY: string;
+      JWT_TOKEN_SCOPE: string;
+      JWT_CLIENT_ASSERTION_TYPE: string;
+    }
+  | {
+      USE_JWT_AUTH?: false;
+    }
+);
+
 export default {
   endpoints: [
     {
@@ -6,7 +35,7 @@ export default {
       FIRST_PAGE: 'https://locally-managed/streams/ldes-1/abb/1',
       TARGET_GRAPH: 'http://mu.semte.ch/graphs/locally-managed',
       STATUS_GRAPH: 'http://mu.semte.ch/graphs/locally-managed/status',
-      EXTRA_HEADERS: {},
+      EXTRA_HEADERS: new Headers(),
       VERSION_PREDICATE: 'http://purl.org/dc/terms/isVersionOf',
       TIME_PREDICATE: 'http://www.w3.org/ns/prov#generatedAtTime',
       NEXT_PAGE_RELATIONSHIP_RDF_TYPE:
@@ -14,5 +43,5 @@ export default {
       SKOLEMIZE_BLANK_NODES: false,
       SKOLEMIZATION_BASE_URI: 'http://mu.semte.ch/bnode/',
     },
-  ],
+  ] satisfies Config[],
 };

--- a/config/config.ts
+++ b/config/config.ts
@@ -6,7 +6,7 @@ export type Config = {
   FIRST_PAGE: string;
   TARGET_GRAPH: string;
   STATUS_GRAPH: string;
-  EXTRA_HEADERS: Headers;
+  EXTRA_HEADERS?: Headers | string;
   VERSION_PREDICATE: string;
   TIME_PREDICATE: string;
   NEXT_PAGE_RELATIONSHIP_RDF_TYPE?: string;

--- a/config/config.ts
+++ b/config/config.ts
@@ -1,3 +1,5 @@
+import type { JWK } from 'jose';
+
 export type Config = {
   name: string;
   LDES_BASE: string;
@@ -14,7 +16,7 @@ export type Config = {
   | {
       USE_JWT_AUTH: true;
       JWT_CLIENT_ID: string;
-      JWT_KEY_PATH: string;
+      JWT_KEY: string | JWK;
       JWT_KEY_ALGORITHM: string;
       JWT_TOKEN_URL: string;
       JWT_TOKEN_REQUEST_AUDIENCE: string;

--- a/cron-fetch-ldes.ts
+++ b/cron-fetch-ldes.ts
@@ -28,6 +28,7 @@ import { Readable } from 'stream';
 import { text } from 'stream/consumers';
 import { BlankNode, NamedNode, Quad } from '@rdfjs/types';
 import processTurtle from './config/processTurtle';
+import { timeout } from './utils';
 
 async function determineFirstPage(): Promise<StateInfo> {
   const state = await loadState();
@@ -126,6 +127,12 @@ async function fetchLdes() {
     const nextPage = await determineNextPage();
     await saveState(state);
     currentPage = nextPage;
+    if (environment.DELAY !== 0) {
+      logger.debug(
+        `Waiting for ${environment.DELAY} milliseconds before processing next page.`,
+      );
+      await timeout(environment.DELAY);
+    }
   }
 
   if (!nothingToDo) {

--- a/cron-fetch-ldes.ts
+++ b/cron-fetch-ldes.ts
@@ -75,7 +75,6 @@ async function loadLDESPage(url: string) {
   if (!headers.has('Accept')) {
     headers.set('Accept', 'text/turtle');
   }
-  console.log('Headers: ', headers);
   const response = await fetch(url, {
     headers,
   });

--- a/cron-fetch-ldes.ts
+++ b/cron-fetch-ldes.ts
@@ -70,11 +70,14 @@ async function clearWorkingGraph() {
 
 async function loadLDESPage(url: string) {
   logger.info(`Loading LDES page ${url}`);
+  const extraHeaders = await environment.getExtraHeaders();
+  const headers = new Headers(extraHeaders);
+  if (!headers.has('Accept')) {
+    headers.set('Accept', 'text/turtle');
+  }
+  console.log('Headers: ', headers);
   const response = await fetch(url, {
-    headers: {
-      Accept: 'text/turtle',
-      ...environment.getExtraHeaders(),
-    },
+    headers,
   });
   if (!response.ok) {
     throw new Error(

--- a/environment.ts
+++ b/environment.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from 'uuid';
-import config from './config/config';
+import config, { Config } from './config/config';
+import { JwtAuthArgs, setJwtAuthHeader } from './jwt';
 
 export const RANDOMIZE_GRAPHS =
   (process.env.RANDOMIZE_GRAPHS || 'false') === 'true';
@@ -28,7 +29,9 @@ export const VERSION_PREDICATE =
 export const TIME_PREDICATE =
   process.env.TIME_PREDICATE || 'http://www.w3.org/ns/prov#generatedAtTime';
 export const LOG_LEVEL = process.env.LOG_LEVEL || 'info';
-export const EXTRA_HEADERS = JSON.parse(process.env.EXTRA_HEADERS || '{}');
+export const EXTRA_HEADERS = new Headers(
+  JSON.parse(process.env.EXTRA_HEADERS || '{}'),
+);
 export const BYPASS_MU_AUTH =
   (process.env.BYPASS_MU_AUTH || 'false') === 'true';
 export const RUN_AT_STARTUP =
@@ -46,6 +49,23 @@ export const SKOLEMIZE_BLANK_NODES =
 const DEFAULT_SKOLEMIZATION_BASE_URI = 'http://mu.semte.ch/bnode/';
 export const SKOLEMIZATION_BASE_URI =
   process.env.SKOLEMIZATION_BASE_URI || DEFAULT_SKOLEMIZATION_BASE_URI;
+
+export const USE_JWT_AUTH = (process.env.USE_JWT_AUTH || 'false') === 'true';
+
+export const JWT_CONFIG = USE_JWT_AUTH
+  ? ({
+      clientId: process.env.JWT_CLIENT_ID,
+      keyPath: process.env.JWT_KEY_PATH ?? '/config/jwk.json',
+      keyAlgorithm: process.env.JWT_KEY_ALGORITHM ?? 'RS256',
+      tokenUrl: process.env.JWT_TOKEN_URL,
+      tokenAudience: process.env.JWT_TOKEN_REQUEST_AUDIENCE,
+      tokenExpiry: process.env.JWT_TOKEN_REQUEST_EXPIRY,
+      tokenScope: process.env.JWT_TOKEN_SCOPE,
+      clientAssertionType:
+        process.env.JWT_CLIENT_ASSERTION_TYPE ??
+        'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+    } as JwtAuthArgs)
+  : undefined;
 
 let currentStream = 0;
 
@@ -85,11 +105,31 @@ export const environment = {
     }
     return config.endpoints[currentStream].STATUS_GRAPH;
   },
-  getExtraHeaders() {
+  async getExtraHeaders() {
     if (LDES_BASE) {
+      const headers = EXTRA_HEADERS;
+      if (USE_JWT_AUTH && JWT_CONFIG) {
+        await setJwtAuthHeader(headers, JWT_CONFIG);
+      }
       return EXTRA_HEADERS;
+    } else {
+      const currentConfig = config.endpoints[currentStream] as Config;
+      const headers = currentConfig.EXTRA_HEADERS;
+      if (currentConfig.USE_JWT_AUTH) {
+        const jwtConfig: JwtAuthArgs = {
+          clientId: currentConfig.JWT_CLIENT_ID,
+          keyPath: currentConfig.JWT_KEY_PATH,
+          keyAlgorithm: currentConfig.JWT_KEY_ALGORITHM,
+          tokenUrl: currentConfig.JWT_TOKEN_URL,
+          tokenAudience: currentConfig.JWT_TOKEN_REQUEST_AUDIENCE,
+          tokenExpiry: currentConfig.JWT_TOKEN_REQUEST_EXPIRY,
+          tokenScope: currentConfig.JWT_TOKEN_SCOPE,
+          clientAssertionType: currentConfig.JWT_CLIENT_ASSERTION_TYPE,
+        };
+        await setJwtAuthHeader(headers, jwtConfig);
+      }
+      return headers;
     }
-    return config.endpoints[currentStream].EXTRA_HEADERS;
   },
   getVersionPredicate() {
     if (LDES_BASE) {

--- a/environment.ts
+++ b/environment.ts
@@ -55,7 +55,7 @@ export const USE_JWT_AUTH = (process.env.USE_JWT_AUTH || 'false') === 'true';
 export const JWT_CONFIG = USE_JWT_AUTH
   ? ({
       clientId: process.env.JWT_CLIENT_ID,
-      keyPath: process.env.JWT_KEY_PATH ?? '/config/jwk.json',
+      key: JSON.parse(process.env.JWT_KEY!),
       keyAlgorithm: process.env.JWT_KEY_ALGORITHM ?? 'RS256',
       tokenUrl: process.env.JWT_TOKEN_URL,
       tokenAudience: process.env.JWT_TOKEN_REQUEST_AUDIENCE,
@@ -118,7 +118,10 @@ export const environment = {
       if (currentConfig.USE_JWT_AUTH) {
         const jwtConfig: JwtAuthArgs = {
           clientId: currentConfig.JWT_CLIENT_ID,
-          keyPath: currentConfig.JWT_KEY_PATH,
+          key:
+            typeof currentConfig.JWT_KEY === 'string'
+              ? JSON.parse(currentConfig.JWT_KEY)
+              : currentConfig.JWT_KEY,
           keyAlgorithm: currentConfig.JWT_KEY_ALGORITHM,
           tokenUrl: currentConfig.JWT_TOKEN_URL,
           tokenAudience: currentConfig.JWT_TOKEN_REQUEST_AUDIENCE,

--- a/environment.ts
+++ b/environment.ts
@@ -114,7 +114,10 @@ export const environment = {
       return EXTRA_HEADERS;
     } else {
       const currentConfig = config.endpoints[currentStream] as Config;
-      const headers = currentConfig.EXTRA_HEADERS;
+      const headers =
+        typeof currentConfig.EXTRA_HEADERS === 'string'
+          ? new Headers(JSON.parse(currentConfig.EXTRA_HEADERS))
+          : (currentConfig.EXTRA_HEADERS ?? new Headers());
       if (currentConfig.USE_JWT_AUTH) {
         const jwtConfig: JwtAuthArgs = {
           clientId: currentConfig.JWT_CLIENT_ID,

--- a/environment.ts
+++ b/environment.ts
@@ -5,6 +5,15 @@ import { JwtAuthArgs, setJwtAuthHeader } from './jwt';
 export const RANDOMIZE_GRAPHS =
   (process.env.RANDOMIZE_GRAPHS || 'false') === 'true';
 export const CRON_PATTERN = process.env.CRON_PATTERN || '*/5 * * * * *';
+
+export const DELAY = Number.parseInt(process.env.DELAY || '0');
+
+if (DELAY < 0 || !Number.isInteger(DELAY)) {
+  throw new Error(
+    `Environment variable DELAY should be a positive integer, got ${DELAY}`,
+  );
+}
+
 export const LDES_BASE = process.env.LDES_BASE;
 export const FIRST_PAGE =
   process.env.FIRST_PAGE ||
@@ -71,6 +80,7 @@ let currentStream = 0;
 
 export const environment = {
   CRON_PATTERN,
+  DELAY,
   WORKING_GRAPH,
   BATCH_GRAPH,
   BATCH_SIZE,

--- a/jwt.ts
+++ b/jwt.ts
@@ -1,4 +1,3 @@
-import { readFile } from 'fs/promises';
 import { v4 as uuidv4 } from 'uuid';
 import { importJWK, JWK, SignJWT } from 'jose';
 import { logger } from './logger';
@@ -12,20 +11,6 @@ type AccessToken = {
 let accessToken: AccessToken | undefined;
 let lastTokenRefresh: number | undefined;
 
-let jwk: JWK | undefined;
-async function getKey(keyPath: string) {
-  if (!jwk) {
-    const keyFile = await readFile(keyPath, { encoding: 'utf8' });
-    jwk = JSON.parse(keyFile);
-    if (!jwk) {
-      throw new Error(
-        `An issue occurred while trying to parse jwk at ${keyPath}`,
-      );
-    }
-  }
-  return jwk;
-}
-
 function isCloseToExpiry(token: AccessToken) {
   const now = Date.now() / 1000;
   return !lastTokenRefresh || now - lastTokenRefresh > token.expires_in * 0.95;
@@ -33,7 +18,7 @@ function isCloseToExpiry(token: AccessToken) {
 
 export interface JwtAuthArgs {
   clientId: string;
-  keyPath: string;
+  key: JWK;
   keyAlgorithm: string;
   tokenUrl: string;
   tokenAudience: string;
@@ -44,7 +29,7 @@ export interface JwtAuthArgs {
 
 async function refreshAccessToken({
   clientId,
-  keyPath,
+  key,
   keyAlgorithm,
   tokenUrl,
   tokenAudience,
@@ -56,7 +41,7 @@ async function refreshAccessToken({
   let tokenReq: Response;
   try {
     lastTokenRefresh = Date.now() / 1000;
-    const secret = await importJWK(await getKey(keyPath));
+    const secret = await importJWK(key);
     const jwt = await new SignJWT({
       iss: clientId,
       sub: clientId,

--- a/jwt.ts
+++ b/jwt.ts
@@ -1,0 +1,121 @@
+import { readFile } from 'fs/promises';
+import { v4 as uuidv4 } from 'uuid';
+import { importJWK, JWK, SignJWT } from 'jose';
+import { logger } from './logger';
+
+type AccessToken = {
+  access_token: string;
+  token_type: string;
+  scope: string;
+  expires_in: number;
+};
+let accessToken: AccessToken | undefined;
+let lastTokenRefresh: number | undefined;
+
+let jwk: JWK | undefined;
+async function getKey(keyPath: string) {
+  if (!jwk) {
+    const keyFile = await readFile(keyPath, { encoding: 'utf8' });
+    jwk = JSON.parse(keyFile);
+    if (!jwk) {
+      throw new Error(
+        `An issue occurred while trying to parse jwk at ${keyPath}`,
+      );
+    }
+  }
+  return jwk;
+}
+
+function isCloseToExpiry(token: AccessToken) {
+  const now = Date.now() / 1000;
+  return !lastTokenRefresh || now - lastTokenRefresh > token.expires_in * 0.95;
+}
+
+export interface JwtAuthArgs {
+  clientId: string;
+  keyPath: string;
+  keyAlgorithm: string;
+  tokenUrl: string;
+  tokenAudience: string;
+  tokenExpiry: string;
+  tokenScope: string;
+  clientAssertionType: string;
+}
+
+async function refreshAccessToken({
+  clientId,
+  keyPath,
+  keyAlgorithm,
+  tokenUrl,
+  tokenAudience,
+  tokenExpiry,
+  tokenScope,
+  clientAssertionType,
+}: JwtAuthArgs) {
+  logger.info('Refreshing access token');
+  let tokenReq: Response;
+  try {
+    lastTokenRefresh = Date.now() / 1000;
+    const secret = await importJWK(await getKey(keyPath));
+    const jwt = await new SignJWT({
+      iss: clientId,
+      sub: clientId,
+      aud: tokenAudience,
+      jti: uuidv4(),
+    })
+      .setProtectedHeader({ alg: keyAlgorithm, typ: 'JWT' })
+      .setIssuedAt()
+      .setExpirationTime(tokenExpiry)
+      .sign(secret);
+
+    tokenReq = await fetch(tokenUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        grant_type: 'client_credentials',
+        client_id: clientId,
+        client_assertion: jwt,
+        client_assertion_type: clientAssertionType,
+        scope: tokenScope,
+      }),
+    });
+  } catch (err) {
+    logger.error('Error while attempting to refresh access token');
+    logger.error(err);
+    process.exit(1);
+  }
+  if (!tokenReq.ok) {
+    logger.error(
+      new Error(
+        `Unexpected response refreshing access token: ${tokenReq.statusText}`,
+      ),
+    );
+    process.exit(1);
+  }
+  return tokenReq.json();
+}
+
+export async function setJwtAuthHeader(
+  headers: Headers,
+  jwtAuthArgs: JwtAuthArgs,
+): Promise<Headers> {
+  if (!accessToken || isCloseToExpiry(accessToken)) {
+    accessToken = await refreshAccessToken(jwtAuthArgs);
+  }
+  if (!accessToken) {
+    throw new Error('no access token when making request');
+  }
+  if (headers.has('Authorization')) {
+    logger.warn(
+      'Cannot pass custom Authorization headers if using JWT auth, overwriting',
+    );
+    headers.delete('Authorization');
+  }
+  headers.append(
+    'Authorization',
+    `${accessToken.token_type} ${accessToken.access_token}`,
+  );
+  return headers;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "cron": "^3.1.7",
         "crypto-js": "^4.0.0",
         "express": "^4.17.1",
+        "jose": "^6.1.0",
         "multer": "^1.4.5-lts.1",
         "rdf-parse": "^4.0.0",
         "rdf-serialize": "^4.0.1",
@@ -4828,6 +4829,15 @@
       },
       "engines": {
         "node": "^18.17 || >=20.6.1"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.0.tgz",
+      "integrity": "sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Service to handle backend business logic for mandataris instances",
   "type": "module",
   "main": "app.js",
+  "type": "module",
   "author": "redpencil.io",
   "license": "MIT",
   "devDependencies": {
@@ -30,6 +31,7 @@
     "cron": "^3.1.7",
     "crypto-js": "^4.0.0",
     "express": "^4.17.1",
+    "jose": "^6.1.0",
     "multer": "^1.4.5-lts.1",
     "rdf-parse": "^4.0.0",
     "rdf-serialize": "^4.0.1",

--- a/utils.ts
+++ b/utils.ts
@@ -1,0 +1,3 @@
+export function timeout(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Description
This PR adds support for JWT based authorization.
It introduces the following env-vars:
- `USE_JWT_AUTH`
- `JWT_CLIENT_ID`
- `JWT_KEY` (can be both passed in encoded and decoded version)
- `JWT_KEY_ALGORITHM`
- `JWT_TOKEN_URL`
- `JWT_TOKEN_REQUEST_AUDIENCE`
- `JWT_TOKEN_REQUEST_EXPIRY`
- `JWT_TOKEN_SCOPE`
- `JWT_CLIENT_ASSERTION_TYPE`

When jwt auth is enabled, the `Authorization` header is overwritten.

## How to test
Example of how we use this feature in GN: https://github.com/lblod/app-gelinkt-notuleren/pull/240
