### PR TITLE
`gatherStateInfo`: use correct https-ldes namespace

### DIFF
--- a/manage-state.ts
+++ b/manage-state.ts
@@ -28,6 +28,8 @@ export const runningState: RunningState = {
 
 export async function gatherStateInfo(currentPage): Promise<StateInfo> {
   const lastTime = await querySudo(
+    // We query both using the `http` and `https` version of the `ldes` namespace.
+    // The `https` one is the correct one, but our internal feeds use the incorrect `http` one.
     /* sparql */ `
     SELECT ?stream ?lastTime ?nextPage WHERE {
       GRAPH ${sparqlEscapeUri(WORKING_GRAPH)} {

--- a/manage-state.ts
+++ b/manage-state.ts
@@ -28,10 +28,16 @@ export const runningState: RunningState = {
 
 export async function gatherStateInfo(currentPage): Promise<StateInfo> {
   const lastTime = await querySudo(
-    `
+    /* sparql */ `
     SELECT ?stream ?lastTime ?nextPage WHERE {
       GRAPH ${sparqlEscapeUri(WORKING_GRAPH)} {
-        ?stream a <http://w3id.org/ldes#EventStream> .
+        {
+          ?stream a <http://w3id.org/ldes#EventStream> .
+        }
+        UNION
+        {
+          ?stream a <https://w3id.org/ldes#EventStream> .
+        }
         OPTIONAL {
           ?stream <https://w3id.org/tree#member> ?versionedMember.
           ?versionedMember ${sparqlEscapeUri(environment.getTimePredicate())} ?lastTime.


### PR DESCRIPTION
## Description
The correct `ldes` namespace is `https://w3id.org/ldes#EventStream` (instead of `http://w3id.org/ldes#EventStream`).
This PR introduces that namespace in the `gatherStateInfo` to ensure it works correctly with all LDES feeds.
It keeps the old (incorrect) http-url to ensure compatibility with our internal feeds.
