### PR TITLE
Introduce support for `DELAY` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Sometimes you may want to do some post processing after the whole stream was pro
 ## Environment Variables
 
 - **CRON_PATTERN**: the cron pattern to use for the LDES client cron job. Default: _/5 _ \* \* \* \*
+- **DELAY**: a delay in milliseconds to introduce between fetching/processing LDES pages. Can be used to reduce load on LDES feed and/or the database. Default: 0. 
 - **FIRST_PAGE**: the url of the first page to load. Default https://mandatenbeheer.lblod.info/streams/ldes/public/1
 - **LDES_BASE**: the base url of the LDES feed. If left blank, uses the config/config.ts file to define properties for one or more LDES feeds (see config file)
 - **STATUS_GRAPH**: the URI of the status graph where this client keeps its status. Default: http://mu.semte.ch/graphs/status

--- a/app.ts
+++ b/app.ts
@@ -40,5 +40,6 @@ setTimeout(() => {
 if (RUN_AT_STARTUP) {
   safeFetchLdes().catch((e) => {
     console.log('Failed to fetch LDES on startup: ', e);
+    process.exit(1);
   });
 }

--- a/cron-fetch-ldes.ts
+++ b/cron-fetch-ldes.ts
@@ -28,6 +28,7 @@ import { Readable } from 'stream';
 import { text } from 'stream/consumers';
 import { BlankNode, NamedNode, Quad } from '@rdfjs/types';
 import processTurtle from './config/processTurtle';
+import { timeout } from './utils';
 
 async function determineFirstPage(): Promise<StateInfo> {
   const state = await loadState();
@@ -126,6 +127,12 @@ async function fetchLdes() {
     const nextPage = await determineNextPage();
     await saveState(state);
     currentPage = nextPage;
+    if (environment.DELAY !== 0) {
+      logger.debug(
+        `Waiting for ${environment.DELAY} milliseconds before processing next page.`,
+      );
+      await timeout(environment.DELAY);
+    }
   }
 
   if (!nothingToDo) {

--- a/environment.ts
+++ b/environment.ts
@@ -5,6 +5,15 @@ import { JwtAuthArgs, setJwtAuthHeader } from './jwt';
 export const RANDOMIZE_GRAPHS =
   (process.env.RANDOMIZE_GRAPHS || 'false') === 'true';
 export const CRON_PATTERN = process.env.CRON_PATTERN || '*/5 * * * * *';
+
+export const DELAY = Number.parseInt(process.env.DELAY || '0');
+
+if (DELAY < 0 || !Number.isInteger(DELAY)) {
+  throw new Error(
+    `Environment variable DELAY should be a positive integer, got ${DELAY}`,
+  );
+}
+
 export const LDES_BASE = process.env.LDES_BASE;
 export const FIRST_PAGE =
   process.env.FIRST_PAGE ||
@@ -71,6 +80,7 @@ let currentStream = 0;
 
 export const environment = {
   CRON_PATTERN,
+  DELAY,
   WORKING_GRAPH,
   BATCH_GRAPH,
   BATCH_SIZE,

--- a/utils.ts
+++ b/utils.ts
@@ -1,0 +1,3 @@
+export function timeout(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Description
This PR introduces support for a configurable `DELAY` parameter. It introduces a delay in milliseconds between fetching/processing LDES pages. Can be used to reduce load on LDES feed and/or the database. Default is `0` (no delay).


## How to test
- Set the `DELAY` environment variable to a positive integer value
- Ensure that between each page processed, the ldes-client waits for `DELAY` milliseconds before proceeding to the next page
- If no `DELAY` env-var is set, the ldes-client does not wait.

## Links to other PR's

