### PR TITLE
Crash when error occurs on startup

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -40,5 +40,6 @@ setTimeout(() => {
 if (RUN_AT_STARTUP) {
   safeFetchLdes().catch((e) => {
     console.log('Failed to fetch LDES on startup: ', e);
+    process.exit(1);
   });
 }


### PR DESCRIPTION
## Description

This PR ensures that the services crashes when running the ingestion on startup and an error occurs.
This behaviour is not ideal, but it ensures correct recovery of the service if `restart: always` is enabled.
This behaviour is also consistent with the fact that if crashes if an error occurs during the cronjob.

## How to test
- Adjust your ldes-client to ensure the ldes feed will not respond with a 2xx status code
- Enable `RUN_AT_STARTUP`
- Start the client
- An error will be thrown during the startup ingestion, the ldes-client should crash.
